### PR TITLE
set dynamic sized matrix as template type in JacobiSVD

### DIFF
--- a/src/DynamicModel.cpp
+++ b/src/DynamicModel.cpp
@@ -55,7 +55,7 @@ base::Matrix6d DynamicModel::calcInvInertiaMatrix(const base::Matrix6d &inertia_
      * M * M^(-1) = I
      * A*x = b
      */
-    Eigen::JacobiSVD<base::Matrix6d> svd(inertia_matrix, Eigen::ComputeThinU | Eigen::ComputeThinV);
+    Eigen::JacobiSVD<base::MatrixXd> svd(inertia_matrix, Eigen::ComputeThinU | Eigen::ComputeThinV);
     return svd.solve(base::Matrix6d::Identity());
 }
 


### PR DESCRIPTION
According to Eigen thin U and V are only available when the matrix has a dynamic number of columns.

The assertions won't be evaluated if Eigen is build on release or EIGEN_NO_DEBUG is defined.